### PR TITLE
change stuff so that it works with 2.1.7

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -10,7 +10,7 @@ module.exports = function (grunt) {
 			rules: {
 				src: [
 					'lib/prolog.stub',
-                                        'lib/goog.js',
+					'lib/modules.js',
 					'lib/utils/*.js',
                                         'lib/checks/**/*.js',
                                         'lib/matchers/*.js',
@@ -18,7 +18,7 @@ module.exports = function (grunt) {
 					'lib/epilog.stub'
 				],
 				dest: 'out/modules.js',
-			},
+			}
 		}
 	});
 

--- a/lib/matchers/clickable-elements-matches.js
+++ b/lib/matchers/clickable-elements-matches.js
@@ -31,31 +31,33 @@ function isClickableElement(node) {
     }
 
     // Framework-specific detection
+    // commenting out because this does not work - modules is undefined
 
     // Angular
-    if (modules.utils.frameworks.angular && node.getAttribute('ng-click')) {
-        return true;
-    }
+    // if ( modules && modules.utils && modules.utils.frameworks &&
+    //   modules.utils.frameworks.angular && node.getAttribute('ng-click')) {
+    //     return true;
+    // }
 
     // jQuery
-    if (modules.utils.frameworks.jquery) {
-        var jQVersion = modules.utils.frameworks.jquery;
-        if (jQVersion.major >= 1) {
-            // Only jQuery >= 1.2.3 and < 1.8 have events accessible from user data name space
-            if (jQVersion.major === 1 && jQVersion.minor < 8) {
-                if (jQVersion.minor >= 2 && !(jQVersion.minor === 2 && jQVersion.dot < 3)) {
-                    if (window.jQuery(node).data('events').click) {
-                        return true;
-                    }
-                }
-            } else {
-                 // jQuery >= 1.8 must use 'undocumented' internal data structure
-                 if (window.jQuery._data(node, 'events').click) {
-                     return true;
-                 }
-            }
-        }
-    }
+    // if (modules.utils.frameworks.jquery) {
+    //     var jQVersion = modules.utils.frameworks.jquery;
+    //     if (jQVersion.major >= 1) {
+    //         // Only jQuery >= 1.2.3 and < 1.8 have events accessible from user data name space
+    //         if (jQVersion.major === 1 && jQVersion.minor < 8) {
+    //             if (jQVersion.minor >= 2 && !(jQVersion.minor === 2 && jQVersion.dot < 3)) {
+    //                 if (window.jQuery(node).data('events').click) {
+    //                     return true;
+    //                 }
+    //             }
+    //         } else {
+    //              // jQuery >= 1.8 must use 'undocumented' internal data structure
+    //              if (window.jQuery._data(node, 'events').click) {
+    //                  return true;
+    //              }
+    //         }
+    //     }
+    // }
 
     return false;
 }

--- a/lib/modules.js
+++ b/lib/modules.js
@@ -1,1 +1,1 @@
-modules = {};
+var modules = modules || {};

--- a/lib/rules/keyboard-reachable.js
+++ b/lib/rules/keyboard-reachable.js
@@ -2,12 +2,32 @@ axe.configure({
     reporter: 'v1',
     checks: [{
           id: 'is-focusable',
-          evaluate: isFocusable
+          evaluate: isFocusable.toString(),
+          enabled: true,
+          metadata: {
+          impact: 'moderate',
+            messages: {
+              pass: 'what did I do right or not do wrong',
+              fail: 'what did I do wrong or fail to do correctly'
+            }
+          }
     }],
     rules: [{
            id: 'keyboard-reachable',
            selector: ':not(button):not(a):not(input):not(textarea):not(select):not(area)',
            matches: isClickableElement.toString(),
            all: [ 'is-focusable' ],
-    }]
+           any: [],
+           none: [],
+           tags: ["custom"],
+           enabled: true
+    }],
+    data: {
+      rules: {
+        'keyboard-reachable': {
+          description: 'description of the rule logic',
+          help: 'what is wrong when the rule fails'
+        }
+      }
+    }
 });


### PR DESCRIPTION
Getting this to work exposes a problem that will have to be fixed in order to make this feasible:

When you stringify the functions they do not take any references along with them, so the references to the `modules` variable cause the execution to throw exceptions. So either write the code to declare `modules` if it does not exist, or attach it to `axe.utils` and reference it from there.

I commented these out for now so that it was working